### PR TITLE
Prevent Argument Exception, Attempt to fix Access Violation

### DIFF
--- a/src/Hud/DPS/DpsMeterPlugin.cs
+++ b/src/Hud/DPS/DpsMeterPlugin.cs
@@ -90,11 +90,14 @@ namespace PoeHUD.Hud.Dps
                 if (hp > -1000000 && hp < 10000000)
                 {
                     int lastHP;
-                    if (lastMonsters.TryGetValue(monster.Id, out lastHP) && lastHP > hp)
+                    if (lastMonsters.TryGetValue(monster.Id, out lastHP))
                     {
-                        totalDamage += lastHP - hp;
+                        // make this a separte if statement to prevent dictionary already containing item
+                        if (lastHP > hp) 
+                        {
+                            totalDamage += lastHP - hp;
+                        }
                     }
-                    monsters.Add(monster.Id, hp);
                 }
             }
             lastMonsters = monsters;

--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -124,17 +124,6 @@ namespace PoeHUD.Hud.Loot
 
         protected override void OnEntityAdded(EntityWrapper entity)
         {
-            // Added a check to see if it's null, will need to figure out why it can be null, if crashes still occur one of the atributes of an entity can be null but only in partyplay (have to investigate).
-            string[] Attributes = new string[] { "Address", "Id", "IsAlive", "IsHostile", "IsValid", "LongId", "Minions", "Path" };
-            for (int i = 0; i != 8; i++ )
-            {
-                string output = "";
-                if (entity.GetType().GetProperty(Attributes[1]).GetValue(entity, null) == null)
-                {
-                    output = output + Attributes[i] + "is null \n";
-                    File.AppendAllText("drawlog", output);
-                }
-            }
             if (Settings.Enable  && entity != null && !GameController.Area.CurrentArea.IsTown && !currentAlerts.ContainsKey(entity) && entity.HasComponent<WorldItem>())
             {
                 IEntity item = entity.GetComponent<WorldItem>().ItemEntity;

--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using PoeHUD.Controllers;

--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 using PoeHUD.Controllers;
 using PoeHUD.Framework.Helpers;
@@ -19,6 +18,7 @@ using PoeHUD.Poe.UI.Elements;
 
 using SharpDX;
 using SharpDX.Direct3D9;
+using System.Collections.Concurrent;
 
 namespace PoeHUD.Hud.Loot
 {
@@ -26,20 +26,20 @@ namespace PoeHUD.Hud.Loot
     {
         private readonly HashSet<long> playedSoundsCache;
 
-        private readonly Dictionary<EntityWrapper, AlertDrawStyle> currentAlerts;
+        private readonly ConcurrentDictionary<EntityWrapper, AlertDrawStyle> currentAlerts;
 
         private readonly Dictionary<string, CraftingBase> craftingBases;
 
         private readonly HashSet<string> currencyNames;
 
-        private Dictionary<int, ItemsOnGroundLabelElement> currentLabels;
+        private ConcurrentDictionary<int, ItemsOnGroundLabelElement> currentLabels;
 
         public ItemAlertPlugin(GameController gameController, Graphics graphics, ItemAlertSettings settings)
             : base(gameController, graphics, settings)
         {
             playedSoundsCache = new HashSet<long>();
-            currentAlerts = new Dictionary<EntityWrapper, AlertDrawStyle>();
-            currentLabels = new Dictionary<int, ItemsOnGroundLabelElement>();
+            currentAlerts = new ConcurrentDictionary<EntityWrapper, AlertDrawStyle>();
+            currentLabels = new ConcurrentDictionary<int, ItemsOnGroundLabelElement>();
             currencyNames = LoadCurrency();
             craftingBases = LoadCraftingBases();
 
@@ -61,18 +61,6 @@ namespace PoeHUD.Hud.Loot
                 const int BOTTOM_MARGIN = 2;
                 bool shouldUpdate = false;
 
-                if (Settings.BorderSettings.Enable)
-                {
-                    Dictionary<EntityWrapper, AlertDrawStyle> tempCopy = new Dictionary<EntityWrapper, AlertDrawStyle>(currentAlerts);
-                    Parallel.ForEach(tempCopy.Where(x => x.Key.IsValid), kv =>
-                    {
-                        if (DrawBorder(kv.Key.Address) && !shouldUpdate)
-                        {
-                            shouldUpdate = true;
-                        }
-                    });
-                }
-
                 foreach (KeyValuePair<EntityWrapper, AlertDrawStyle> kv in currentAlerts.Where(x => x.Key.IsValid))
                 {
                     string text = GetItemName(kv);
@@ -84,11 +72,15 @@ namespace PoeHUD.Hud.Loot
                     ItemsOnGroundLabelElement entityLabel;
                     if (currentLabels.TryGetValue(kv.Key.Address, out entityLabel))
                     {
-                        // Don't make labels on the right for items we can't pick up UNTIL we can pick it up or invisible
-                        if (Settings.HideOthers && !entityLabel.CanPickUp)
+                        if (Settings.BorderSettings.Enable && DrawBorder(kv.Key.Address) && !shouldUpdate)
                         {
-                            return;
+                                shouldUpdate = true;
                         }
+                        // Don't make labels on the right for items we can't pick up UNTIL we can pick it up or invisible
+                        //if (Settings.HideOthers && !entityLabel.CanPickUp)
+                        //{
+                        //    return;
+                        //}
                     }
                     else
                     {
@@ -104,7 +96,8 @@ namespace PoeHUD.Hud.Loot
 
                 if (shouldUpdate)
                 {
-                    currentLabels = GameController.Game.IngameState.IngameUi.ItemsOnGroundLabels.ToDictionary(y => y.ItemOnGround.Address, y => y);
+                    // Change this in the future to prevent problems (create separate thread to do the updating, thread safe calls)
+                    currentLabels = new ConcurrentDictionary<int, ItemsOnGroundLabelElement> (GameController.Game.IngameState.IngameUi.ItemsOnGroundLabels.ToDictionary(y => y.ItemOnGround.Address, y => y));
                 }
             }
         }
@@ -131,7 +124,7 @@ namespace PoeHUD.Hud.Loot
                 if (props.ShouldAlert(currencyNames, Settings))
                 {
                     AlertDrawStyle drawStyle = props.GetDrawStyle();
-                    currentAlerts.Add(entity, drawStyle);
+                    currentAlerts.TryAdd(entity, drawStyle);
                     CurrentIcons[entity] = new MapIcon(entity, new HudTexture("minimap_default_icon.png", drawStyle.AlertColor), () => Settings.ShowItemOnMap, 8);
 
                     if (Settings.PlaySound && !playedSoundsCache.Contains(entity.LongId))
@@ -146,8 +139,10 @@ namespace PoeHUD.Hud.Loot
         protected override void OnEntityRemoved(EntityWrapper entity)
         {
             base.OnEntityRemoved(entity);
-            currentAlerts.Remove(entity);
-            currentLabels.Remove(entity.Address);
+            AlertDrawStyle ignoredStyle;
+            currentAlerts.TryRemove(entity, out ignoredStyle);
+            ItemsOnGroundLabelElement ignoredLabel;
+            currentLabels.TryRemove(entity.Address, out ignoredLabel);
         }
 
         private static Dictionary<string, CraftingBase> LoadCraftingBases()
@@ -244,8 +239,7 @@ namespace PoeHUD.Hud.Loot
                         if (Settings.BorderSettings.ShowTimer && timeLeft.TotalMilliseconds > 0)
                         {
                             borderColor = Settings.BorderSettings.CantPickUpBorderColor;
-                            Graphics.DrawText(timeLeft.ToString(@"mm\:ss"), Settings.BorderSettings.TimerTextSize,
-                                rect.TopRight.Translate(4, 0));
+                            Graphics.DrawText(timeLeft.ToString(@"mm\:ss"), Settings.BorderSettings.TimerTextSize, rect.TopRight.Translate(4, 0));
                         }
                     }
                     Graphics.DrawFrame(rect, Settings.BorderSettings.BorderWidth, borderColor);

--- a/src/Hud/Loot/ItemAlertSettings.cs
+++ b/src/Hud/Loot/ItemAlertSettings.cs
@@ -12,7 +12,7 @@ namespace PoeHUD.Hud.Loot
             ShowItemOnMap = true;
             Crafting = true;
             ShowText = true;
-            HideOthers = false;
+            //HideOthers = false;
             PlaySound = true;
             TextSize = new RangeNode<int>(25, 10, 50);
             Rares = true;
@@ -32,7 +32,7 @@ namespace PoeHUD.Hud.Loot
 
         public ToggleNode ShowText { get; set; }
 
-        public ToggleNode HideOthers { get; set; }
+        //public ToggleNode HideOthers { get; set; }
 
         public ToggleNode PlaySound { get; set; }
 

--- a/src/Hud/Menu/MenuPlugin.cs
+++ b/src/Hud/Menu/MenuPlugin.cs
@@ -154,7 +154,7 @@ namespace PoeHUD.Hud.Menu
             AddChild(qualitySkillGemMenu, "Min. quality", qualityItemsSettings.SkillGem.MinQuality);
             AddChild(itemAlertMenu, "Play sound", settingsHub.ItemAlertSettings.PlaySound);
             MenuItem alertTextMenu = AddChild(itemAlertMenu, "Show text", settingsHub.ItemAlertSettings.ShowText);
-            AddChild(itemAlertMenu, "Hide Others", settingsHub.ItemAlertSettings.HideOthers);
+            //AddChild(itemAlertMenu, "Hide Others", settingsHub.ItemAlertSettings.HideOthers);
             AddChild(alertTextMenu, "Font size", settingsHub.ItemAlertSettings.TextSize);
             BorderSettings borderSettings = settingsHub.ItemAlertSettings.BorderSettings;
             MenuItem showBorderMenu = AddChild(itemAlertMenu, "Show border", borderSettings.Enable);

--- a/src/Hud/UI/Renderers/FontRenderer.cs
+++ b/src/Hud/UI/Renderers/FontRenderer.cs
@@ -30,16 +30,21 @@ namespace PoeHUD.Hud.UI.Renderers
 
         public Size2 DrawText(string text, string fontName, int height, Vector2 position, Color color, FontDrawFlags align)
         {
-            try {
-                Font font = GetFont(fontName, height);
+            Font font;
+            Rectangle fontDimension;
+            try
+            {
+                font = GetFont(fontName, height);
                 var rectangle = new Rectangle((int)position.X, (int)position.Y, 0, 0);
-                Rectangle fontDimension = font.MeasureText(null, text, rectangle, align);
-                font.DrawText(sprite, text, fontDimension, align, color);
+                fontDimension = font.MeasureText(null, text, rectangle, align);
+                if (!sprite.IsDisposed)
+                    font.DrawText(sprite, text, fontDimension, align, color);
                 return new Size2(fontDimension.Width, fontDimension.Height);
             }
             catch (Exception exception)
             {
-                // Console.WriteLine("Exception! " + position.X + ", " + position.Y);
+                //Console.WriteLine("Exception! X: " + position.X + ", Y: " + position.Y + ", Text: " + text);
+                //Console.WriteLine(exception.StackTrace);
             }
             return new Size2();
         }

--- a/src/Hud/UI/Renderers/FontRenderer.cs
+++ b/src/Hud/UI/Renderers/FontRenderer.cs
@@ -37,9 +37,9 @@ namespace PoeHUD.Hud.UI.Renderers
                 font.DrawText(sprite, text, fontDimension, align, color);
                 return new Size2(fontDimension.Width, fontDimension.Height);
             }
-            catch (AccessViolationException exception)
+            catch (Exception exception)
             {
-                // Console.WriteLine("Access Violation! " + position.X + ", " + position.Y);
+                // Console.WriteLine("Exception! " + position.X + ", " + position.Y);
             }
             return new Size2();
         }


### PR DESCRIPTION
Prevent ArgumentException due to health regen/revive.
Work towards preventing access violation exceptions.
Removed separate ForEach thread for DrawBorder and re-implement into single thread (UI Thread).
Changed dictionary over to ConcurrentDictionary (thread safe).
Check for disposed Sprite before attempting to draw text.
Changed debug output on exception catch, commented for releases.
Disabled "Hide Others" option for now as the "can pick up" check is incorrect at times.
Removed unused "imports"
Removed Logging inside of Item Alert entity Add.
