### PR TITLE
fixed XpRatePlugin bug

### DIFF
--- a/src/Hud/XpRate/XpRatePlugin.cs
+++ b/src/Hud/XpRate/XpRatePlugin.cs
@@ -60,6 +60,14 @@ namespace PoeHUD.Hud.XpRate
             var bounds = new RectangleF(position.X - boxWidth + 5, position.Y - 5, boxWidth, boxHeight + 10);
 
             string systemTime = string.Format("{0} ({1})", nowTime.ToShortTimeString(), GameController.Game.IngameState.CurFps);
+            Size2 timeFpsSize = Graphics.MeasureText(systemTime, fontSize);
+            var dif =bounds.Width - (12 + timeFpsSize.Width + xpRateSize.Width);
+            if (dif < 0)
+            {
+                bounds.X += dif;
+                bounds.Width -= dif;
+            }
+
             Graphics.DrawText(systemTime, fontSize, new Vector2(bounds.X + 5, position.Y), Color.White);
             Graphics.DrawText(timer, fontSize, new Vector2(bounds.X + 5, thirdLine.Y), Color.White);
 


### PR DESCRIPTION
*EXP/Hour the text gets covered by other numbers if my exp/hour is 3 digits
![fix](https://cloud.githubusercontent.com/assets/1619549/8079045/cf476500-0f6a-11e5-8f9a-c17fd7609a67.png)

Sorry, i forgot 1 line, now all correcct))
