### PR TITLE
Added Regex support for crafting_bases.txt

### DIFF
--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace PoeHUD.Hud.Loot
@@ -371,7 +372,15 @@ namespace PoeHUD.Hud.Loot
             CraftingBase craftingBase = new CraftingBase();
             if (Settings.Crafting)
             {
-                craftingBases.TryGetValue(name, out craftingBase);
+                foreach (KeyValuePair<string, CraftingBase> cb in craftingBases)
+                {
+                    if (cb.Key.Equals(name)
+                        || (new Regex(cb.Value.Name)).Match(name).Success)
+                    {
+                        craftingBase = cb.Value;
+                        break;
+                    }
+                }
             }
 
             return new ItemUsefulProperties(name, item, craftingBase);


### PR DESCRIPTION
Hello!

I decided to make a little update because I use it in my purposes. I enabled Regex support in crafting_bases.txt. Now instead of writing every item in it own line I can write for example:
^(Q|A|G|R|T).*?\sFlask
To get Ruby, Topaz etc. flasks.
I tested and have not found any errors. Let me know if you find some.
Maybe useful for someone.

Best regards
